### PR TITLE
Added a dependency on the mustache library.

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,9 @@
   "bugs": {
     "url": "https://github.com/rsenden/node-red-contrib-map/issues"
   },
+  "dependencies": {
+    "mustache": "^4.2.0"
+  },
   "homepage": "https://github.com/rsenden/node-red-contrib-map#readme",
   "node-red": {
     "nodes": {


### PR DESCRIPTION
After adding node-red-contrib-map to a flow and attempting to deploy it, I got an error:

```
30 May 15:10:11 - [info] Waiting for missing types to be registered:
30 May 15:10:11 - [info]  - map-config
30 May 15:10:11 - [info]  - map-map
```

The Node-RED error log indicates that it can't find the 'mustache' library:

```
30 May 15:09:06 - [info]  - node-red-contrib-map:map-switch : Error: Cannot find module 'mustache'
Require stack:
- C:\Users\david\.node-red\node_modules\node-red-contrib-map\map.js
- C:\Users\david\AppData\Local\nvs\node\12.11.1\x64\node_modules\node-red\node_modules\@node-red\registry\lib\loader.js
- C:\Users\david\AppData\Local\nvs\node\12.11.1\x64\node_modules\node-red\node_modules\@node-red\registry\lib\index.js
- C:\Users\david\AppData\Local\nvs\node\12.11.1\x64\node_modules\node-red\node_modules\@node-red\runtime\lib\nodes\index.js
- C:\Users\david\AppData\Local\nvs\node\12.11.1\x64\node_modules\node-red\node_modules\@node-red\runtime\lib\index.js
- C:\Users\david\AppData\Local\nvs\node\12.11.1\x64\node_modules\node-red\lib\red.js
- C:\Users\david\AppData\Local\nvs\node\12.11.1\x64\node_modules\node-red\red.js
```

This PR adds mustache as a dependency.